### PR TITLE
Fix P1: preserve selected drive lifetime and report quarantine move failures

### DIFF
--- a/cleanai/src/Core/QuarantineManager.cpp
+++ b/cleanai/src/Core/QuarantineManager.cpp
@@ -2,6 +2,7 @@
 
 #include <Windows.h>
 #include <chrono>
+#include <stdexcept>
 #include <format>
 
 namespace CleanAI::Core
@@ -32,7 +33,10 @@ namespace CleanAI::Core
         auto target = sessionPath / relative;
         std::filesystem::create_directories(target.parent_path());
 
-        MoveFileExW(filePath.c_str(), target.wstring().c_str(), MOVEFILE_COPY_ALLOWED | MOVEFILE_WRITE_THROUGH);
+        if (!MoveFileExW(filePath.c_str(), target.wstring().c_str(), MOVEFILE_COPY_ALLOWED | MOVEFILE_WRITE_THROUGH))
+        {
+            throw std::runtime_error("Failed to move file into quarantine");
+        }
         co_return target.wstring();
     }
 

--- a/cleanai/src/Pages/ScanPage.cpp
+++ b/cleanai/src/Pages/ScanPage.cpp
@@ -20,7 +20,8 @@ namespace CleanAI::Pages
         auto combo = FindName(L"DriveCombo").as<winrt::Microsoft::UI::Xaml::Controls::ComboBox>();
         if (!combo.SelectedItem()) co_return;
 
-        auto root = winrt::unbox_value<winrt::hstring>(combo.SelectedItem()).c_str();
+        auto selectedDrive = winrt::unbox_value<winrt::hstring>(combo.SelectedItem());
+        auto root = selectedDrive.c_str();
 
         auto files = co_await m_scanner->ScanAsync(root, [this](Core::ScanProgress const& progress)
         {


### PR DESCRIPTION
### **User description**
### Motivation
- Prevent a dangling pointer when starting a scan by ensuring the selected drive string outlives the `c_str()` call to `ScanAsync`.
- Avoid reporting successful quarantine operations when `MoveFileExW` fails (e.g., file locked or access denied) so callers receive an error instead of incorrect state.

### Description
- Updated `cleanai/src/Pages/ScanPage.cpp` to store the selected drive as a local `winrt::hstring` (`selectedDrive`) before calling `c_str()` and passing the pointer to `DiskScanner::ScanAsync`.
- Updated `cleanai/src/Core/QuarantineManager.cpp` to check the return value of `MoveFileExW` and throw a `std::runtime_error` on failure, and added the `<stdexcept>` include.

### Testing
- Ran `cmake -S cleanai -B cleanai/build` in this environment which failed as expected due to the project guard that restricts the build to Windows 11 (`CMakeLists.txt`), so Windows build and runtime tests were not executed here.
- No automated Windows build/test could be run in this Linux CI; the changes are minimal and should be validated by running a full build and quarantine integration tests on Windows 11 (Visual Studio 2022) where `MoveFileExW` behavior and `DiskScanner::ScanAsync` can be exercised.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69922e023be8832cbc2a6ed7dfae2432)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix dangling pointer in scan by preserving selected drive lifetime

- Add error handling for quarantine file move operations

- Throw exception when MoveFileExW fails instead of silently continuing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ScanPage::OnScan"] -->|Before: dangling pointer| B["c_str on temporary"]
  A -->|After: preserved lifetime| C["selectedDrive variable"]
  C -->|Safe pointer| D["ScanAsync"]
  E["MoveFileExW call"] -->|Before: silent failure| F["Success assumed"]
  E -->|After: check return| G["Throw exception"]
  G -->|Error propagated| H["Caller notified"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ScanPage.cpp</strong><dd><code>Preserve selected drive lifetime in scan operation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cleanai/src/Pages/ScanPage.cpp

<ul><li>Store selected drive as local <code>winrt::hstring</code> variable before calling <br><code>c_str()</code><br> <li> Prevents dangling pointer by ensuring the string outlives the pointer <br>usage<br> <li> Maintains same functionality while fixing lifetime issue</ul>


</details>


  </td>
  <td><a href="https://github.com/ARTEMKOPIK/CllineAI/pull/2/files#diff-1fb4e756d8388281e799261afdb4835cf7f721d9a4a9fd1603c942296eb39857">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>QuarantineManager.cpp</strong><dd><code>Add error handling for quarantine file moves</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cleanai/src/Core/QuarantineManager.cpp

<ul><li>Add <code>#include <stdexcept></code> header for exception handling<br> <li> Check return value of <code>MoveFileExW</code> and throw <code>std::runtime_error</code> on <br>failure<br> <li> Prevents silent failures when file move operations are blocked (locked <br>files, access denied)</ul>


</details>


  </td>
  <td><a href="https://github.com/ARTEMKOPIK/CllineAI/pull/2/files#diff-65216b594dee6851f4b1adf90fe2f67b7f9f0ae4dec69022e500e11acd7bf75d">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

