### PR TITLE
Fix GitHub Actions CMake configure for Microsoft.WindowsAppSDK

### DIFF
--- a/.github/workflows/build-and-release-exe.yml
+++ b/.github/workflows/build-and-release-exe.yml
@@ -40,12 +40,43 @@ jobs:
           # It is not a vcpkg port, so only install the packages that vcpkg actually provides.
           & "$env:VCPKG_ROOT/vcpkg.exe" install cpprestsdk:x64-windows sqlite3:x64-windows
 
+      - name: Resolve Microsoft.WindowsAppSDK CMake package path
+        shell: pwsh
+        run: |
+          $vswhere = Join-Path "${env:ProgramFiles(x86)}" "Microsoft Visual Studio/Installer/vswhere.exe"
+          if (-not (Test-Path $vswhere)) {
+            throw "vswhere.exe was not found at expected location: $vswhere"
+          }
+
+          $vsPath = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationPath
+          if (-not $vsPath) {
+            throw "Could not detect a Visual Studio installation path via vswhere.exe"
+          }
+
+          $cmakeExtensionsRoot = Join-Path $vsPath "Common7/IDE/CommonExtensions/Microsoft/CMake/CMakeExtensions"
+          if (-not (Test-Path $cmakeExtensionsRoot)) {
+            throw "CMake extensions path was not found: $cmakeExtensionsRoot"
+          }
+
+          $configPath = Get-ChildItem -Path $cmakeExtensionsRoot -Filter "Microsoft.WindowsAppSDKConfig.cmake" -Recurse -ErrorAction SilentlyContinue |
+            Sort-Object FullName -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+
+          if (-not $configPath) {
+            throw "Microsoft.WindowsAppSDKConfig.cmake was not found under: $cmakeExtensionsRoot"
+          }
+
+          $windowsAppSdkCmakeDir = Split-Path $configPath -Parent
+          "WINDOWS_APP_SDK_CMAKE_DIR=$windowsAppSdkCmakeDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          Write-Host "Resolved Microsoft.WindowsAppSDK_DIR=$windowsAppSdkCmakeDir"
+
       - name: Configure CMake (Release)
         shell: pwsh
         run: |
           cmake -S cleanai -B build -G "Visual Studio 17 2022" -A x64 `
             -DCMAKE_BUILD_TYPE=Release `
-            -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
+            -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" `
+            -DMicrosoft.WindowsAppSDK_DIR="$env:WINDOWS_APP_SDK_CMAKE_DIR"
 
       - name: Build CleanAI
         shell: pwsh


### PR DESCRIPTION
### **User description**
### Motivation

- GitHub Actions runs on `windows-latest` sometimes fail because `find_package(Microsoft.WindowsAppSDK REQUIRED CONFIG)` does not reliably auto-discover the SDK installed by the Visual Studio toolchain. 
- Make package discovery deterministic during the workflow CMake configure step to avoid intermittent CI failures.

### Description

- Added a PowerShell workflow step `Resolve Microsoft.WindowsAppSDK CMake package path` that uses `vswhere.exe` to locate `Microsoft.WindowsAppSDKConfig.cmake`, validates the path and exports it to `GITHUB_ENV` as `WINDOWS_APP_SDK_CMAKE_DIR`.
- Updated the CMake configuration step to pass `-DMicrosoft.WindowsAppSDK_DIR="$env:WINDOWS_APP_SDK_CMAKE_DIR"` so `find_package` can find the package config deterministically.
- Kept the `vcpkg` install limited to `cpprestsdk:x64-windows` and `sqlite3:x64-windows` and added explicit error checks to fail fast if `vswhere` or the CMake config file cannot be found.

### Testing

- Ran `git -C /workspace/CllineAI diff --check` and it returned no issues (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699239fea82c832cb75b8589e2709e26)


___

### **PR Type**
Bug fix


___

### **Description**
- Adds PowerShell step to reliably resolve Microsoft.WindowsAppSDK CMake package path using vswhere.exe

- Exports resolved path to GITHUB_ENV for deterministic package discovery

- Passes resolved path to CMake configure via -DMicrosoft.WindowsAppSDK_DIR flag

- Includes explicit error checks for vswhere, Visual Studio installation, and CMake config file


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["vswhere.exe locates VS installation"] --> B["Find CMakeExtensions directory"]
  B --> C["Locate Microsoft.WindowsAppSDKConfig.cmake"]
  C --> D["Export path to GITHUB_ENV"]
  D --> E["CMake configure uses resolved path"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-and-release-exe.yml</strong><dd><code>Add deterministic WindowsAppSDK CMake package resolution</code>&nbsp; </dd></summary>
<hr>

.github/workflows/build-and-release-exe.yml

<ul><li>Added new PowerShell workflow step "Resolve Microsoft.WindowsAppSDK <br>CMake package path" that uses vswhere.exe to locate Visual Studio <br>installation<br> <li> Searches for Microsoft.WindowsAppSDKConfig.cmake under CMake <br>extensions directory with recursive search and descending sort<br> <li> Exports resolved directory path to GITHUB_ENV as <br>WINDOWS_APP_SDK_CMAKE_DIR variable<br> <li> Updated CMake configure step to pass -DMicrosoft.WindowsAppSDK_DIR <br>flag with the resolved environment variable<br> <li> Added comprehensive error handling to fail fast if vswhere, Visual <br>Studio installation, or CMake config file cannot be found</ul>


</details>


  </td>
  <td><a href="https://github.com/ARTEMKOPIK/CllineAI/pull/5/files#diff-e77f3df32bf44b8c74f3d69f47f7a7feb45ccf1210875be61a8123c4a5be93d0">+32/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

