### PR TITLE
Добавить поиск MSVC runtime (VCToolsRedistDir) в workflow упаковки релиза

### DIFF
--- a/.github/workflows/build-and-release-exe.yml
+++ b/.github/workflows/build-and-release-exe.yml
@@ -105,7 +105,10 @@ jobs:
 
           if ($env:VCToolsRedistDir) {
             $vcRedistDirs = Get-ChildItem -Path $env:VCToolsRedistDir -Directory -Recurse -ErrorAction SilentlyContinue |
-              Where-Object { $_.Name -ieq 'Microsoft.VC143.CRT' } |
+              Where-Object {
+                $_.Name -ieq 'Microsoft.VC143.CRT' -and
+                $_.FullName -imatch '[\\/]x64[\\/]'
+              } |
               ForEach-Object { $_.FullName }
 
             foreach ($dir in $vcRedistDirs) {


### PR DESCRIPTION
### **User description**
### Motivation
- Шаг упаковки релиза в GitHub Actions падал из-за того, что `dumpbin` находил MSVC CRT DLL (например `vcruntime`, `msvcp`) которые не были в `build/Release` или `vcpkg` и не находились текущими путями поиска.
- Нужно добавить поиск в каталоги редистрибутива инструментов компилятора, чтобы корректно находить и копировать runtime-библиотеки на GitHub-hosted Windows раннерах.

### Description
- В `.github/workflows/build-and-release-exe.yml` в шаге `Prepare distributable bundle` добавлен блок, который при наличии переменной окружения `VCToolsRedistDir` рекурсивно ищет папки `Microsoft.VC143.CRT` и добавляет их в массив путей поиска `$searchDirs`.
- Логика поиска зависимостей осталась прежней; новые пути просто расширяют набор директорий, где ищутся DLL перед попыткой пометить их как отсутствующие.
- Изменение обратно-совместимо: если `VCToolsRedistDir` отсутствует, поведение не меняется.

### Testing
- Просмотрен и проверен workflow через `rg --files .github/workflows` и `sed -n` для контроля внесённого фрагмента, команда выполнились успешно.
- Проверка синтаксиса с `actionlint .github/workflows/build-and-release-exe.yml` не выполнена из-за отсутствия `actionlint` в окружении (`bash: command not found: actionlint`).
- Подтверждён дифф внесённых изменений через `git diff` и просмотр фрагмента файла через `nl -ba .github/workflows/build-and-release-exe.yml | sed -n '90,150p'` — вставка путей поиска присутствует и корректна.
- Полный прогон Windows job не выполнялся в этом окружении, но правка ограничена добавлением путей поиска и совместима при отсутствии переменной `VCToolsRedistDir`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69923c1995bc832cb1acbcbde5aabf89)


___

### **PR Type**
Bug fix


___

### **Description**
- Add MSVC runtime DLL search path from VCToolsRedistDir environment variable

- Recursively find Microsoft.VC143.CRT directories in redistributable tools

- Extend dependency search directories to locate runtime libraries correctly

- Maintain backward compatibility when VCToolsRedistDir is not set


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["VCToolsRedistDir<br/>environment variable"] -->|"Check if set"| B["Search for<br/>Microsoft.VC143.CRT"]
  B -->|"Find directories"| C["Add to<br/>searchDirs array"]
  C -->|"Extended paths"| D["Locate runtime DLLs<br/>correctly"]
  E["Existing search paths<br/>releaseOutputDir<br/>vcpkg bin"] -->|"Combined with"| D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-and-release-exe.yml</strong><dd><code>Add VCToolsRedistDir search path for runtime DLLs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build-and-release-exe.yml

<ul><li>Added conditional block to check for VCToolsRedistDir environment <br>variable<br> <li> Recursively searches for Microsoft.VC143.CRT directories within <br>VCToolsRedistDir<br> <li> Appends found CRT directories to the searchDirs array for DLL <br>dependency resolution<br> <li> Maintains backward compatibility with silent error handling when <br>VCToolsRedistDir is absent</ul>


</details>


  </td>
  <td><a href="https://github.com/ARTEMKOPIK/CllineAI/pull/6/files#diff-e77f3df32bf44b8c74f3d69f47f7a7feb45ccf1210875be61a8123c4a5be93d0">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

