### PR TITLE
Fix directory skip logic in DiskScanner recursive scan

### DIFF
--- a/cleanai/src/Core/DiskScanner.cpp
+++ b/cleanai/src/Core/DiskScanner.cpp
@@ -21,8 +21,11 @@ namespace CleanAI::Core
                 root,
                 std::filesystem::directory_options::skip_permission_denied);
 
-            for (auto const& entry : iterator)
+            auto end = std::filesystem::recursive_directory_iterator();
+            for (; iterator != end; ++iterator)
             {
+                auto const& entry = *iterator;
+
                 if (entry.is_directory() && ShouldSkipDirectory(entry.path().wstring()))
                 {
                     iterator.disable_recursion_pending();


### PR DESCRIPTION
### **User description**
### Motivation
- The recursive directory scan could still descend into excluded folders (e.g. `Windows`, `Program Files`) because encountering a blocked directory only `continue`d the loop without disabling recursion, causing wasted work and incorrect scanning behavior.

### Description
- Updated `cleanai/src/Core/DiskScanner.cpp` to construct a named `std::filesystem::recursive_directory_iterator` instead of using a temporary range.
- When a directory matches `ShouldSkipDirectory`, the code now calls `iterator.disable_recursion_pending()` to prevent descending into its subtree and then `continue`s the loop.
- No other behavioral changes to file collection, progress reporting, or the `ShouldSkipDirectory` list were made.

### Testing
- Applied the patch and verified the resulting diff of `cleanai/src/Core/DiskScanner.cpp` contained the intended changes and compiled-path logic adjustments, which succeeded. 
- Ran `cmake -S cleanai -B /tmp/cleanai-build` to validate configuration, which failed as expected because the project enforces a Windows-only target (`CleanAI поддерживает только Windows 11 22H2+`).
- No full Windows build was performed in this environment due to platform restrictions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69923e06f8f0832cb8880376d4a3bb4e)


___

### **PR Type**
Bug fix


___

### **Description**
- Prevent recursive descent into excluded directories

- Use named iterator to call `disable_recursion_pending()`

- Avoid wasted work scanning blocked folder subtrees


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Directory Iterator"] -->|"Check if skip"| B["ShouldSkipDirectory"]
  B -->|"Match found"| C["Call disable_recursion_pending"]
  C -->|"Continue loop"| D["Skip subtree"]
  B -->|"No match"| E["Process entry"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DiskScanner.cpp</strong><dd><code>Prevent recursion into skipped directories</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

cleanai/src/Core/DiskScanner.cpp

<ul><li>Changed from temporary range-based iterator to named <code>iterator</code> variable<br> <li> Added <code>iterator.disable_recursion_pending()</code> call when directory matches <br>skip criteria<br> <li> Prevents recursive descent into excluded directories like <code>Windows</code> and <br><code>Program Files</code><br> <li> Maintains all other scanning behavior and progress reporting logic</ul>


</details>


  </td>
  <td><a href="https://github.com/ARTEMKOPIK/CllineAI/pull/7/files#diff-ebb3ebb4ceef8d20226c699c5372521c72fd0739672216201a6097a6f19823a0">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

