### PR TITLE
Fix WindowsAppSDK CMake package resolution in CI workflow

### DIFF
--- a/.github/workflows/build-and-release-exe.yml
+++ b/.github/workflows/build-and-release-exe.yml
@@ -40,33 +40,33 @@ jobs:
           # It is not a vcpkg port, so only install the packages that vcpkg actually provides.
           & "$env:VCPKG_ROOT/vcpkg.exe" install cpprestsdk:x64-windows sqlite3:x64-windows
 
-      - name: Resolve Microsoft.WindowsAppSDK CMake package path
+      - name: Install Microsoft.WindowsAppSDK CMake package
         shell: pwsh
         run: |
-          $vswhere = Join-Path "${env:ProgramFiles(x86)}" "Microsoft Visual Studio/Installer/vswhere.exe"
-          if (-not (Test-Path $vswhere)) {
-            throw "vswhere.exe was not found at expected location: $vswhere"
+          if (Get-Command nuget -ErrorAction SilentlyContinue) {
+            $nuget = "nuget"
+          }
+          else {
+            $nuget = Join-Path $env:RUNNER_TEMP "nuget.exe"
+            Invoke-WebRequest -Uri "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe" -OutFile $nuget
           }
 
-          $vsPath = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationPath
-          if (-not $vsPath) {
-            throw "Could not detect a Visual Studio installation path via vswhere.exe"
+          $windowsAppSdkVersion = "1.5.240607001"
+          $windowsAppSdkPackagesDir = Join-Path $env:RUNNER_TEMP "nuget-packages"
+
+          & $nuget install Microsoft.WindowsAppSDK `
+            -Version $windowsAppSdkVersion `
+            -OutputDirectory $windowsAppSdkPackagesDir `
+            -Source "https://api.nuget.org/v3/index.json" `
+            -NonInteractive
+
+          $windowsAppSdkCmakeDir = Join-Path $windowsAppSdkPackagesDir "Microsoft.WindowsAppSDK.$windowsAppSdkVersion/build/native"
+          $windowsAppSdkConfig = Join-Path $windowsAppSdkCmakeDir "Microsoft.WindowsAppSDKConfig.cmake"
+
+          if (-not (Test-Path $windowsAppSdkConfig)) {
+            throw "Microsoft.WindowsAppSDKConfig.cmake was not found after NuGet install: $windowsAppSdkConfig"
           }
 
-          $cmakeExtensionsRoot = Join-Path $vsPath "Common7/IDE/CommonExtensions/Microsoft/CMake/CMakeExtensions"
-          if (-not (Test-Path $cmakeExtensionsRoot)) {
-            throw "CMake extensions path was not found: $cmakeExtensionsRoot"
-          }
-
-          $configPath = Get-ChildItem -Path $cmakeExtensionsRoot -Filter "Microsoft.WindowsAppSDKConfig.cmake" -Recurse -ErrorAction SilentlyContinue |
-            Sort-Object FullName -Descending |
-            Select-Object -First 1 -ExpandProperty FullName
-
-          if (-not $configPath) {
-            throw "Microsoft.WindowsAppSDKConfig.cmake was not found under: $cmakeExtensionsRoot"
-          }
-
-          $windowsAppSdkCmakeDir = Split-Path $configPath -Parent
           "WINDOWS_APP_SDK_CMAKE_DIR=$windowsAppSdkCmakeDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           Write-Host "Resolved Microsoft.WindowsAppSDK_DIR=$windowsAppSdkCmakeDir"
 


### PR DESCRIPTION
### **User description**
### Motivation
- The previous CI step attempted to locate `Microsoft.WindowsAppSDKConfig.cmake` by probing Visual Studio internals, which is brittle across runner images and caused Actions failures.
- The goal is to make Windows App SDK discovery deterministic and robust so the `cmake` configure step finds the SDK reliably on `windows-latest` runners.

### Description
- Replaced the fragile VS layout discovery step in `.github/workflows/build-and-release-exe.yml` with an explicit NuGet install of `Microsoft.WindowsAppSDK` and set `WINDOWS_APP_SDK_CMAKE_DIR` to the package `build/native` folder.
- Added a fallback to download `nuget.exe` when the `nuget` command is not available on the runner so the step works on clean images.
- Added an explicit existence check for `Microsoft.WindowsAppSDKConfig.cmake` after NuGet install and fail early with a clear error if it is missing.
- Kept the rest of the CI flow unchanged (vcpkg install, CMake configure/build, bundling and release upload).

### Testing
- Validated the changed workflow is syntactically valid YAML by loading `.github/workflows/build-and-release-exe.yml` with `python` and `pyyaml`, which produced `YAML_OK`.
- Installed `pyyaml` via `python -m pip install --quiet pyyaml` and used a small Python assertion that `jobs.build-and-release` exists in the parsed workflow, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69923e760530832c9656bc14fe109cc6)


___

### **PR Type**
Bug fix


___

### **Description**
- Replace fragile Visual Studio layout probing with explicit NuGet install

- Add fallback to download nuget.exe when unavailable on runner

- Set WINDOWS_APP_SDK_CMAKE_DIR to NuGet package build/native folder

- Add explicit existence check for Microsoft.WindowsAppSDKConfig.cmake


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old: VS Layout Probing"] -->|vswhere + CMakeExtensions| B["Fragile Discovery"]
  C["New: NuGet Install"] -->|Microsoft.WindowsAppSDK 1.5| D["Deterministic Resolution"]
  E["Fallback: Download nuget.exe"] -->|if not available| D
  D -->|Set WINDOWS_APP_SDK_CMAKE_DIR| F["CMake Configure"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-and-release-exe.yml</strong><dd><code>Replace VS probing with NuGet-based SDK resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build-and-release-exe.yml

<ul><li>Replaced Visual Studio vswhere-based discovery with explicit NuGet <br>package installation<br> <li> Added conditional logic to use system nuget or download nuget.exe as <br>fallback<br> <li> Hardcoded Microsoft.WindowsAppSDK version 1.5.240607001 for <br>deterministic resolution<br> <li> Simplified CMake directory resolution by using NuGet package structure <br>instead of recursive search<br> <li> Added explicit validation that Microsoft.WindowsAppSDKConfig.cmake <br>exists after install</ul>


</details>


  </td>
  <td><a href="https://github.com/ARTEMKOPIK/CllineAI/pull/8/files#diff-e77f3df32bf44b8c74f3d69f47f7a7feb45ccf1210875be61a8123c4a5be93d0">+18/-18</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

