### PR TITLE
ci: fail release step when artifact upload to release fails

### DIFF
--- a/.github/workflows/build-and-release-exe.yml
+++ b/.github/workflows/build-and-release-exe.yml
@@ -223,6 +223,7 @@ jobs:
 
             Commit: ${{ github.sha }}
           artifacts: release/CleanAI-windows-x64.zip
+          artifactErrorsFailBuild: true
           allowUpdates: true
           removeArtifacts: true
           replacesArtifacts: true


### PR DESCRIPTION
### **User description**
### Motivation
- Ensure the release job fails explicitly when publishing artifacts to GitHub Releases encounters an error so CI does not silently succeed on a bad release.

### Description
- Added `artifactErrorsFailBuild: true` to the `ncipollo/release-action` `with:` block in `.github/workflows/build-and-release-exe.yml` so artifact publish errors cause the job to fail.

### Testing
- Verified workflow YAML parses with `ruby -e 'require "yaml"; d=YAML.load_file(".github/workflows/build-and-release-exe.yml")'` and returns a mapping containing `jobs` (success).
- Ran `yamllint` with a relaxed ruleset to validate syntax (`yamllint -d '{extends: default, rules: {line-length: disable, truthy: disable, document-start: disable}}' .github/workflows/build-and-release-exe.yml`) and it reported no blocking issues (success).
- Attempted to run local Actions emulation via `act -l`, but `act` is not installed in this environment (could not run local execution).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699242b9a7dc832cbbb1e783751ccea2)


___

### **PR Type**
Bug fix


___

### **Description**
- Adds `artifactErrorsFailBuild: true` to release action configuration

- Ensures CI fails explicitly when artifact upload fails

- Prevents silent success on failed GitHub Releases publishing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Release Action Configuration"] -- "Add artifactErrorsFailBuild: true" --> B["Explicit Job Failure on Upload Error"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-and-release-exe.yml</strong><dd><code>Add artifact error handling to release action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build-and-release-exe.yml

<ul><li>Added <code>artifactErrorsFailBuild: true</code> parameter to <br><code>ncipollo/release-action</code> step<br> <li> Ensures the release job fails when artifact publishing to GitHub <br>Releases encounters errors<br> <li> Prevents CI from silently succeeding on failed artifact uploads</ul>


</details>


  </td>
  <td><a href="https://github.com/ARTEMKOPIK/CllineAI/pull/10/files#diff-e77f3df32bf44b8c74f3d69f47f7a7feb45ccf1210875be61a8123c4a5be93d0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

