### PR TITLE
Codex-generated pull request

### DIFF
--- a/.github/workflows/build-and-release-exe.yml
+++ b/.github/workflows/build-and-release-exe.yml
@@ -44,9 +44,28 @@ jobs:
           # It is not a vcpkg port, so only install the packages that vcpkg actually provides.
           & "$env:VCPKG_ROOT/vcpkg.exe" install cpprestsdk:x64-windows sqlite3:x64-windows
 
-      - name: Install Microsoft.WindowsAppSDK CMake package
+      - name: Configure CMake (Release)
         shell: pwsh
         run: |
+          function Invoke-CmakeConfigure([string[]]$extraArgs) {
+            & cmake -S cleanai -B build -G "Visual Studio 17 2022" -A x64 `
+              -DCMAKE_BUILD_TYPE=Release `
+              -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" `
+              @extraArgs
+
+            return ($LASTEXITCODE -eq 0)
+          }
+
+          # First try: use Windows App SDK from preinstalled Visual Studio components.
+          if (Invoke-CmakeConfigure @()) {
+            Write-Host "CMake configure succeeded with preinstalled Microsoft.WindowsAppSDK."
+            exit 0
+          }
+
+          Write-Warning "CMake configure failed with preinstalled SDK. Trying NuGet fallback..."
+
+          Remove-Item -Path build -Recurse -Force -ErrorAction SilentlyContinue
+
           if (Get-Command nuget -ErrorAction SilentlyContinue) {
             $nuget = "nuget"
           }
@@ -55,32 +74,48 @@ jobs:
             Invoke-WebRequest -Uri "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe" -OutFile $nuget
           }
 
-          $windowsAppSdkVersion = "1.5.240607001"
           $windowsAppSdkPackagesDir = Join-Path $env:RUNNER_TEMP "nuget-packages"
+          $candidateVersions = @(
+            "1.7.250401001",
+            "1.6.240923002",
+            "1.5.240607001"
+          )
 
-          & $nuget install Microsoft.WindowsAppSDK `
-            -Version $windowsAppSdkVersion `
-            -OutputDirectory $windowsAppSdkPackagesDir `
-            -Source "https://api.nuget.org/v3/index.json" `
-            -NonInteractive
+          $resolvedWindowsAppSdkCmakeDir = $null
 
-          $windowsAppSdkCmakeDir = Join-Path $windowsAppSdkPackagesDir "Microsoft.WindowsAppSDK.$windowsAppSdkVersion/build/native"
-          $windowsAppSdkConfig = Join-Path $windowsAppSdkCmakeDir "Microsoft.WindowsAppSDKConfig.cmake"
+          foreach ($version in $candidateVersions) {
+            Write-Host "Trying Microsoft.WindowsAppSDK $version from NuGet..."
 
-          if (-not (Test-Path $windowsAppSdkConfig)) {
-            throw "Microsoft.WindowsAppSDKConfig.cmake was not found after NuGet install: $windowsAppSdkConfig"
+            & $nuget install Microsoft.WindowsAppSDK `
+              -Version $version `
+              -OutputDirectory $windowsAppSdkPackagesDir `
+              -Source "https://api.nuget.org/v3/index.json" `
+              -NonInteractive
+
+            if ($LASTEXITCODE -ne 0) {
+              Write-Warning "NuGet install failed for Microsoft.WindowsAppSDK $version"
+              continue
+            }
+
+            $candidateDir = Join-Path $windowsAppSdkPackagesDir "Microsoft.WindowsAppSDK.$version/build/native"
+            $candidateConfig = Join-Path $candidateDir "Microsoft.WindowsAppSDKConfig.cmake"
+            if (Test-Path $candidateConfig) {
+              $resolvedWindowsAppSdkCmakeDir = $candidateDir
+              break
+            }
+
+            Write-Warning "Microsoft.WindowsAppSDKConfig.cmake not found for version $version"
           }
 
-          "WINDOWS_APP_SDK_CMAKE_DIR=$windowsAppSdkCmakeDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          Write-Host "Resolved Microsoft.WindowsAppSDK_DIR=$windowsAppSdkCmakeDir"
+          if (-not $resolvedWindowsAppSdkCmakeDir) {
+            throw "Failed to resolve Microsoft.WindowsAppSDKConfig.cmake from preinstalled tooling and NuGet fallback."
+          }
 
-      - name: Configure CMake (Release)
-        shell: pwsh
-        run: |
-          cmake -S cleanai -B build -G "Visual Studio 17 2022" -A x64 `
-            -DCMAKE_BUILD_TYPE=Release `
-            -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" `
-            -DMicrosoft.WindowsAppSDK_DIR="$env:WINDOWS_APP_SDK_CMAKE_DIR"
+          Write-Host "Resolved Microsoft.WindowsAppSDK_DIR=$resolvedWindowsAppSdkCmakeDir"
+
+          if (-not (Invoke-CmakeConfigure @("-DMicrosoft.WindowsAppSDK_DIR=$resolvedWindowsAppSdkCmakeDir"))) {
+            throw "CMake configure failed even after resolving Microsoft.WindowsAppSDK_DIR=$resolvedWindowsAppSdkCmakeDir"
+          }
 
       - name: Build CleanAI
         shell: pwsh


### PR DESCRIPTION
### **User description**
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699246629668832c9eff5406cc004aa9)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Implement multi-version fallback strategy for WindowsAppSDK resolution

- Add preinstalled SDK detection before NuGet fallback attempt

- Support multiple WindowsAppSDK versions (1.7, 1.6, 1.5)

- Refactor CMake configuration into reusable function with error handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CMake Configure"] --> B{"Preinstalled SDK<br/>Available?"}
  B -->|Yes| C["Success"]
  B -->|No| D["Try NuGet Fallback"]
  D --> E["Iterate Candidate<br/>Versions"]
  E --> F{"Version<br/>Found?"}
  F -->|Yes| G["Configure with SDK"]
  F -->|No| H["Error"]
  G --> C
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-and-release-exe.yml</strong><dd><code>Multi-version WindowsAppSDK resolution with fallback strategy</code></dd></summary>
<hr>

.github/workflows/build-and-release-exe.yml

<ul><li>Refactored WindowsAppSDK installation into a two-stage resolution <br>process with preinstalled detection first<br> <li> Extracted CMake configuration into <code>Invoke-CmakeConfigure</code> function for <br>reusability and error handling<br> <li> Replaced hardcoded version "1.5.240607001" with candidate versions <br>array supporting 1.7, 1.6, and 1.5<br> <li> Added loop to iterate through candidate versions with individual error <br>handling and validation<br> <li> Improved error messages and logging throughout the resolution process</ul>


</details>


  </td>
  <td><a href="https://github.com/ARTEMKOPIK/CllineAI/pull/11/files#diff-e77f3df32bf44b8c74f3d69f47f7a7feb45ccf1210875be61a8123c4a5be93d0">+55/-20</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

