### PR TITLE
ci: fix failing Windows build step by forcing package restore

### DIFF
--- a/.github/workflows/build-and-release-exe.yml
+++ b/.github/workflows/build-and-release-exe.yml
@@ -120,7 +120,10 @@ jobs:
       - name: Build CleanAI
         shell: pwsh
         run: |
-          cmake --build build --config Release --target CleanAI
+          # Explicitly restore NuGet packages during build. This prevents intermittent
+          # MSBuild failures on hosted runners where Windows App SDK targets/packages
+          # are not restored for the generated CMake solution yet.
+          cmake --build build --config Release --target CleanAI -- /restore /m
 
       - name: Prepare distributable bundle (EXE + runtime dependencies)
         shell: pwsh


### PR DESCRIPTION
### **User description**
### Motivation
- The Windows CI job (run `22044210081`, job `63690093477`) was failing during the "Build CleanAI" step after a successful CMake configure due to intermittent MSBuild / missing NuGet package/Windows App SDK target resolution on hosted runners.

### Description
- Update `.github/workflows/build-and-release-exe.yml` to run the build with an explicit MSBuild restore by replacing the build command with `cmake --build build --config Release --target CleanAI -- /restore /m` and add a short explanatory comment.

### Testing
- Validated the modified workflow YAML parsed successfully with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/build-and-release-exe.yml')"`, inspected the `git diff` and committed the change as `ci: restore NuGet packages during Windows build`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699248fab044832c8c7bb7ecd3b3d816)


___

### **PR Type**
Bug fix


___

### **Description**
- Add explicit NuGet package restore to Windows build step

- Prevents intermittent MSBuild failures on hosted runners

- Includes explanatory comment for future maintainers


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CMake Build Command"] -->|"Add /restore /m flags"| B["Explicit NuGet Restore"]
  B -->|"Prevents missing packages"| C["Successful MSBuild"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-and-release-exe.yml</strong><dd><code>Add NuGet restore flags to Windows build step</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build-and-release-exe.yml

<ul><li>Modified the "Build CleanAI" step to include explicit NuGet package <br>restore flags<br> <li> Added <code>/restore /m</code> parameters to the cmake build command<br> <li> Added multi-line comment explaining the rationale for the change<br> <li> Prevents intermittent MSBuild failures related to Windows App SDK <br>target resolution</ul>


</details>


  </td>
  <td><a href="https://github.com/ARTEMKOPIK/CllineAI/pull/12/files#diff-e77f3df32bf44b8c74f3d69f47f7a7feb45ccf1210875be61a8123c4a5be93d0">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

