### PR TITLE
Fix Windows CI Build step by using explicit MSBuild restore

### DIFF
--- a/.github/workflows/build-and-release-exe.yml
+++ b/.github/workflows/build-and-release-exe.yml
@@ -120,10 +120,20 @@ jobs:
       - name: Build CleanAI
         shell: pwsh
         run: |
-          # Explicitly restore NuGet packages during build. This prevents intermittent
-          # MSBuild failures on hosted runners where Windows App SDK targets/packages
-          # are not restored for the generated CMake solution yet.
-          cmake --build build --config Release --target CleanAI -- /restore /m
+          # Restore NuGet packages explicitly before build. Passing '/restore' through
+          # `cmake --build` is unreliable with Visual Studio generators because CMake
+          # may invoke a backend that does not accept that switch.
+          $solutionPath = "build/CleanAI.sln"
+          if (-not (Test-Path $solutionPath)) {
+            throw "Expected Visual Studio solution not found: $solutionPath"
+          }
+
+          & msbuild $solutionPath /t:Restore /p:Configuration=Release /p:Platform=x64 /m
+          if ($LASTEXITCODE -ne 0) {
+            throw "MSBuild restore failed with exit code $LASTEXITCODE"
+          }
+
+          cmake --build build --config Release --target CleanAI --parallel
 
       - name: Prepare distributable bundle (EXE + runtime dependencies)
         shell: pwsh


### PR DESCRIPTION
### **User description**
### Motivation
- The Windows CI run was failing in the `Build CleanAI` step because `/restore` was forwarded through `cmake --build`, which is unreliable for Visual Studio generator backends. 
- The failure manifested as an intermittent MSBuild/restore error during the build step of the workflow run `22044376729`. 
- The goal is to make the restore step backend-appropriate and the build step deterministic on GitHub-hosted Windows runners. 

### Description
- Replace the unreliable forwarded flags with an explicit `msbuild build/CleanAI.sln /t:Restore /p:Configuration=Release /p:Platform=x64 /m` restore invocation. 
- Add a fail-fast check that the generated Visual Studio solution exists via `Test-Path "build/CleanAI.sln"` and throw a clear error if it is missing. 
- Run the compilation with `cmake --build build --config Release --target CleanAI --parallel` after restore, removing the forwarded `/restore /m` switches. 

### Testing
- Queried the GitHub Actions job metadata for job `63690513466` and confirmed the `Build CleanAI` step (step 7) was the failing step, which motivated the change; this check succeeded. 
- Inspected the workflow file diff and confirmed the patch touches only the `Build CleanAI` step to add the `msbuild` restore, the solution existence check, and the revised `cmake --build` invocation; this inspection succeeded. 
- Attempted to parse the workflow YAML locally using `python` with `yaml.safe_load`, but local `PyYAML` was not available so automated YAML parsing could not be completed in this environment (validation not performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69924bf7df04832c92b103ff5bd2cd2f)


___

### **PR Type**
Bug fix


___

### **Description**
- Replace unreliable `/restore` flag forwarding through `cmake --build` with explicit MSBuild restore invocation

- Add solution file existence check with clear error message

- Separate restore and build steps for deterministic Windows CI execution

- Improve error handling with exit code validation for MSBuild restore


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CMake Configure"] --> B["Check Solution Exists"]
  B --> C["MSBuild Restore"]
  C --> D["Validate Exit Code"]
  D --> E["CMake Build"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-and-release-exe.yml</strong><dd><code>Explicit MSBuild restore with validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build-and-release-exe.yml

<ul><li>Replaced unreliable <code>cmake --build</code> with <code>/restore</code> flag with explicit <br><code>msbuild</code> restore command<br> <li> Added <code>Test-Path</code> check to verify Visual Studio solution file exists <br>before restore<br> <li> Added exit code validation after MSBuild restore with descriptive <br>error message<br> <li> Simplified <code>cmake --build</code> invocation by removing <code>/restore /m</code> flags and <br>using <code>--parallel</code> instead</ul>


</details>


  </td>
  <td><a href="https://github.com/ARTEMKOPIK/CllineAI/pull/13/files#diff-e77f3df32bf44b8c74f3d69f47f7a7feb45ccf1210875be61a8123c4a5be93d0">+14/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

