### PR TITLE
Codex-generated pull request

### DIFF
--- a/.github/workflows/build-and-release-exe.yml
+++ b/.github/workflows/build-and-release-exe.yml
@@ -123,14 +123,57 @@ jobs:
           # Restore NuGet packages explicitly before build. Passing '/restore' through
           # `cmake --build` is unreliable with Visual Studio generators because CMake
           # may invoke a backend that does not accept that switch.
-          $solutionPath = "build/CleanAI.sln"
-          if (-not (Test-Path $solutionPath)) {
-            throw "Expected Visual Studio solution not found: $solutionPath"
+          #
+          # We use multiple restore strategies + retries because hosted runners
+          # occasionally fail to resolve package feeds on the first attempt.
+          function Invoke-WithRetry([scriptblock]$Action, [string]$Description, [int]$MaxAttempts = 3, [int]$DelaySeconds = 10) {
+            for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+              Write-Host "[$attempt/$MaxAttempts] $Description"
+              & $Action
+              if ($LASTEXITCODE -eq 0) {
+                return
+              }
+
+              if ($attempt -lt $MaxAttempts) {
+                Write-Warning "$Description failed with exit code $LASTEXITCODE. Retrying in $DelaySeconds seconds..."
+                Start-Sleep -Seconds $DelaySeconds
+              }
+            }
+
+            throw "$Description failed after $MaxAttempts attempts"
           }
 
-          & msbuild $solutionPath /t:Restore /p:Configuration=Release /p:Platform=x64 /m
-          if ($LASTEXITCODE -ne 0) {
-            throw "MSBuild restore failed with exit code $LASTEXITCODE"
+          $solutionPath = "build/CleanAI.sln"
+          if (-not (Test-Path $solutionPath)) {
+            $detectedSolutions = Get-ChildItem -Path build -Filter *.sln -File -ErrorAction SilentlyContinue
+            if ($detectedSolutions.Count -eq 1) {
+              $solutionPath = $detectedSolutions[0].FullName
+              Write-Warning "Using detected solution path: $solutionPath"
+            }
+            else {
+              throw "Expected Visual Studio solution not found at build/CleanAI.sln and auto-detection failed."
+            }
+          }
+
+          if (Get-Command nuget -ErrorAction SilentlyContinue) {
+            $nuget = "nuget"
+          }
+          else {
+            $nuget = Join-Path $env:RUNNER_TEMP "nuget.exe"
+            Invoke-WebRequest -Uri "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe" -OutFile $nuget
+          }
+
+          # First restore pass: nuget.exe with explicit sources for better resiliency.
+          Invoke-WithRetry -Description "NuGet restore" -Action {
+            & $nuget restore $solutionPath `
+              -NonInteractive `
+              -Verbosity detailed `
+              -Source "https://api.nuget.org/v3/index.json;https://www.nuget.org/api/v2"
+          }
+
+          # Second restore pass: msbuild restore with hardened restore settings.
+          Invoke-WithRetry -Description "MSBuild restore" -Action {
+            & msbuild $solutionPath /t:Restore /p:Configuration=Release /p:Platform=x64 /p:RestoreRetryCount=5 /p:RestoreDisableParallel=true /p:RestoreIgnoreFailedSources=true /m
           }
 
           cmake --build build --config Release --target CleanAI --parallel


### PR DESCRIPTION
### **User description**
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69924e661030832cba6b07e19ef3eed8)


___

### **PR Type**
Enhancement


___

### **Description**
- Add retry logic with exponential backoff for NuGet package restoration

- Implement dual restore strategy using nuget.exe and msbuild

- Auto-detect solution file if default path not found

- Harden Windows build process with improved error handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Build CleanAI Step"] --> B["Detect Solution File"]
  B --> C["Download/Locate nuget.exe"]
  C --> D["NuGet Restore with Retry"]
  D --> E["MSBuild Restore with Retry"]
  E --> F["CMake Build"]
  D -.->|Retry on Failure| D
  E -.->|Retry on Failure| E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-and-release-exe.yml</strong><dd><code>Implement resilient multi-strategy NuGet restore with retries</code></dd></summary>
<hr>

.github/workflows/build-and-release-exe.yml

<ul><li>Added <code>Invoke-WithRetry</code> helper function to retry failed operations with <br>configurable attempts and delays<br> <li> Implemented solution file auto-detection when default path is not <br>found<br> <li> Added nuget.exe download logic with fallback to system installation<br> <li> Replaced single MSBuild restore with dual-pass strategy: nuget.exe <br>restore followed by MSBuild restore with hardened parameters<br> <li> Enhanced error messages and logging throughout the build process</ul>


</details>


  </td>
  <td><a href="https://github.com/ARTEMKOPIK/CllineAI/pull/14/files#diff-e77f3df32bf44b8c74f3d69f47f7a7feb45ccf1210875be61a8123c4a5be93d0">+47/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

