### PR TITLE
Codex-generated pull request

### DIFF
--- a/.github/workflows/build-and-release-exe.yml
+++ b/.github/workflows/build-and-release-exe.yml
@@ -123,26 +123,6 @@ jobs:
           # Restore NuGet packages explicitly before build. Passing '/restore' through
           # `cmake --build` is unreliable with Visual Studio generators because CMake
           # may invoke a backend that does not accept that switch.
-          #
-          # We use multiple restore strategies + retries because hosted runners
-          # occasionally fail to resolve package feeds on the first attempt.
-          function Invoke-WithRetry([scriptblock]$Action, [string]$Description, [int]$MaxAttempts = 3, [int]$DelaySeconds = 10) {
-            for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
-              Write-Host "[$attempt/$MaxAttempts] $Description"
-              & $Action
-              if ($LASTEXITCODE -eq 0) {
-                return
-              }
-
-              if ($attempt -lt $MaxAttempts) {
-                Write-Warning "$Description failed with exit code $LASTEXITCODE. Retrying in $DelaySeconds seconds..."
-                Start-Sleep -Seconds $DelaySeconds
-              }
-            }
-
-            throw "$Description failed after $MaxAttempts attempts"
-          }
-
           $solutionPath = "build/CleanAI.sln"
           if (-not (Test-Path $solutionPath)) {
             $detectedSolutions = Get-ChildItem -Path build -Filter *.sln -File -ErrorAction SilentlyContinue
@@ -155,25 +135,9 @@ jobs:
             }
           }
 
-          if (Get-Command nuget -ErrorAction SilentlyContinue) {
-            $nuget = "nuget"
-          }
-          else {
-            $nuget = Join-Path $env:RUNNER_TEMP "nuget.exe"
-            Invoke-WebRequest -Uri "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe" -OutFile $nuget
-          }
-
-          # First restore pass: nuget.exe with explicit sources for better resiliency.
-          Invoke-WithRetry -Description "NuGet restore" -Action {
-            & $nuget restore $solutionPath `
-              -NonInteractive `
-              -Verbosity detailed `
-              -Source "https://api.nuget.org/v3/index.json;https://www.nuget.org/api/v2"
-          }
-
-          # Second restore pass: msbuild restore with hardened restore settings.
-          Invoke-WithRetry -Description "MSBuild restore" -Action {
-            & msbuild $solutionPath /t:Restore /p:Configuration=Release /p:Platform=x64 /p:RestoreRetryCount=5 /p:RestoreDisableParallel=true /p:RestoreIgnoreFailedSources=true /m
+          & msbuild $solutionPath /t:Restore /p:Configuration=Release /p:Platform=x64 /m
+          if ($LASTEXITCODE -ne 0) {
+            throw "MSBuild restore failed with exit code $LASTEXITCODE"
           }
 
           cmake --build build --config Release --target CleanAI --parallel


### PR DESCRIPTION
### **User description**
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69924fed82cc832c80a28f82d811fe77)


___

### **PR Type**
Bug fix


___

### **Description**
- Removed retry logic and NuGet download mechanism from build step

- Simplified restore process to single MSBuild command

- Added error handling for restore failures

- Reduced complexity and potential failure points


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Complex retry logic<br/>+ NuGet download"] -->|Removed| B["Simple MSBuild restore"]
  B -->|Added| C["Direct error handling"]
  C -->|Result| D["Faster, more reliable build"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-and-release-exe.yml</strong><dd><code>Simplify NuGet restore in build workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build-and-release-exe.yml

<ul><li>Removed <code>Invoke-WithRetry</code> function that handled retry logic with delays<br> <li> Removed NuGet.exe download and explicit NuGet restore pass<br> <li> Replaced dual restore strategy with single MSBuild restore command<br> <li> Added simple error checking for restore exit code</ul>


</details>


  </td>
  <td><a href="https://github.com/ARTEMKOPIK/CllineAI/pull/15/files#diff-e77f3df32bf44b8c74f3d69f47f7a7feb45ccf1210875be61a8123c4a5be93d0">+3/-39</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

