### PR TITLE
Codex-generated pull request

### DIFF
--- a/.github/workflows/build-and-release-exe.yml
+++ b/.github/workflows/build-and-release-exe.yml
@@ -120,9 +120,9 @@ jobs:
       - name: Build CleanAI
         shell: pwsh
         run: |
-          # Restore NuGet packages explicitly before build. Passing '/restore' through
-          # `cmake --build` is unreliable with Visual Studio generators because CMake
-          # may invoke a backend that does not accept that switch.
+          # Try explicit restore first. Some generated Visual Studio solutions do not
+          # expose the Restore target (for example, pure native C++ projects without
+          # NuGet references), so restore failures are treated as non-fatal.
           $solutionPath = "build/CleanAI.sln"
           if (-not (Test-Path $solutionPath)) {
             $detectedSolutions = Get-ChildItem -Path build -Filter *.sln -File -ErrorAction SilentlyContinue
@@ -137,7 +137,7 @@ jobs:
 
           & msbuild $solutionPath /t:Restore /p:Configuration=Release /p:Platform=x64 /m
           if ($LASTEXITCODE -ne 0) {
-            throw "MSBuild restore failed with exit code $LASTEXITCODE"
+            Write-Warning "MSBuild restore failed with exit code $LASTEXITCODE. Continuing to build because Restore may be unavailable for this generated native solution."
           }
 
           cmake --build build --config Release --target CleanAI --parallel


### PR DESCRIPTION
### **User description**
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699252488394832ca833bb0816f5f7e0)


___

### **PR Type**
Bug fix


___

### **Description**
- Handle missing Restore target in Visual Studio solutions gracefully

- Convert MSBuild restore failure from fatal to non-fatal error

- Allow build to continue when Restore target unavailable

- Improve error handling for native C++ projects without NuGet


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MSBuild Restore Attempt"] --> B{"Restore Target Available?"}
  B -->|Yes| C["Restore Succeeds"]
  B -->|No| D["Log Warning"]
  C --> E["Continue Build"]
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-and-release-exe.yml</strong><dd><code>Make MSBuild restore failure non-fatal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build-and-release-exe.yml

<ul><li>Updated comment to explain Restore target may be unavailable in native <br>C++ projects<br> <li> Changed MSBuild restore failure from throwing exception to logging <br>warning<br> <li> Build now continues even if Restore target is not exposed in solution<br> <li> Improved error handling for generated Visual Studio solutions</ul>


</details>


  </td>
  <td><a href="https://github.com/ARTEMKOPIK/CllineAI/pull/16/files#diff-e77f3df32bf44b8c74f3d69f47f7a7feb45ccf1210875be61a8123c4a5be93d0">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

