### PR TITLE
ci: проверка наличия `msbuild` в шаге Build CleanAI

### DIFF
--- a/.github/workflows/build-and-release-exe.yml
+++ b/.github/workflows/build-and-release-exe.yml
@@ -135,9 +135,15 @@ jobs:
             }
           }
 
-          & msbuild $solutionPath /t:Restore /p:Configuration=Release /p:Platform=x64 /m
-          if ($LASTEXITCODE -ne 0) {
-            Write-Warning "MSBuild restore failed with exit code $LASTEXITCODE. Continuing to build because Restore may be unavailable for this generated native solution."
+          $msbuild = Get-Command msbuild -ErrorAction SilentlyContinue
+          if ($msbuild) {
+            & $msbuild.Source $solutionPath /t:Restore /p:Configuration=Release /p:Platform=x64 /m
+            if ($LASTEXITCODE -ne 0) {
+              Write-Warning "MSBuild restore failed with exit code $LASTEXITCODE. Continuing to build because Restore may be unavailable for this generated native solution."
+            }
+          }
+          else {
+            Write-Warning "MSBuild is not available in PATH after MSVC setup. Skipping explicit restore and continuing with CMake build."
           }
 
           cmake --build build --config Release --target CleanAI --parallel


### PR DESCRIPTION
### **User description**
### Motivation
- Шаг `Build CleanAI` в workflow падал мгновенно на Windows-раннере из‑за неразрешённой команды `msbuild`, что ломало сборку. 
- Нужно безопасно пропустить явный `Restore`, если `msbuild` недоступен, и продолжить сборку через `cmake`, чтобы CI не фейлился по этой простой причине.

### Description
- Добавлена проверка наличия `msbuild` через `Get-Command msbuild -ErrorAction SilentlyContinue` перед вызовом restore. 
- Вызов `msbuild … /t:Restore` выполняется только если `msbuild` найден; в противном случае выводится предупреждение и сборка продолжается через `cmake --build`. 
- Логика автопоиска `*.sln` и остальная последовательность сборки не затронуты.

### Testing
- Запуск `git diff --check` показал, что файл workflow корректно изменён и без ошибок. (успех)
- Попытка валидировать YAML с помощью `python` и `yaml.safe_load` не завершилась из‑за отсутствия модуля `yaml` в окружении, что является ограничением среды, а не ошибкой изменения. (не выполнено из‑за окружения)
- Проверка метаданных GitHub Actions через `curl` подтвердила, что раньше падение было на шаге `Build CleanAI`, что соответствует исправленной проблеме. (успех)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699253be3a74832c92227e276a557aff)


___

### **PR Type**
Bug fix


___

### **Description**
- Add msbuild availability check before restore step

- Skip explicit restore if msbuild unavailable in PATH

- Continue build via cmake when msbuild not found

- Prevent workflow failure on Windows runners without msbuild


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Build CleanAI Step"] --> B{"msbuild available?"}
  B -->|Yes| C["Execute msbuild restore"]
  C --> D["Check exit code"]
  D -->|Success| E["Continue to cmake build"]
  D -->|Failure| F["Warn and continue"]
  F --> E
  B -->|No| G["Warn and skip restore"]
  G --> E["Continue to cmake build"]
  E --> H["Build with cmake"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-and-release-exe.yml</strong><dd><code>Add conditional msbuild check before restore</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build-and-release-exe.yml

<ul><li>Added <code>Get-Command msbuild</code> check to detect msbuild availability<br> <li> Wrapped msbuild restore call in conditional block<br> <li> Execute restore only if msbuild is found in PATH<br> <li> Added warning message when msbuild is unavailable</ul>


</details>


  </td>
  <td><a href="https://github.com/ARTEMKOPIK/CllineAI/pull/17/files#diff-e77f3df32bf44b8c74f3d69f47f7a7feb45ccf1210875be61a8123c4a5be93d0">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

