### PR TITLE
Исправление автоопределения `.sln` в Windows CI workflow

### DIFF
--- a/.github/workflows/build-and-release-exe.yml
+++ b/.github/workflows/build-and-release-exe.yml
@@ -125,7 +125,7 @@ jobs:
           # NuGet references), so restore failures are treated as non-fatal.
           $solutionPath = "build/CleanAI.sln"
           if (-not (Test-Path $solutionPath)) {
-            $detectedSolutions = Get-ChildItem -Path build -Filter *.sln -File -ErrorAction SilentlyContinue
+            $detectedSolutions = @(Get-ChildItem -Path build -Filter *.sln -File -ErrorAction SilentlyContinue)
             if ($detectedSolutions.Count -eq 1) {
               $solutionPath = $detectedSolutions[0].FullName
               Write-Warning "Using detected solution path: $solutionPath"


### PR DESCRIPTION
### **User description**
### Motivation
- Исправить падение шага `Build CleanAI` в workflow, вызванное тем, что `Get-ChildItem` при единственном найденном файле может вернуть не массив, из‑за чего проверка `$detectedSolutions.Count -eq 1` срабатывала некорректно.

### Description
- Обернул результат `Get-ChildItem` в явный массив `@(Get-ChildItem -Path build -Filter *.sln -File -ErrorAction SilentlyContinue)` в файле `.github/workflows/build-and-release-exe.yml`, чтобы корректно обрабатывать случаи с 0/1/N `.sln` файлов.

### Testing
- Подтвердил через GitHub Actions API, что проблема проявлялась в шаге сборки, проверил и применил `diff` для `.github/workflows/build-and-release-exe.yml`, и отметил, что локальный запуск шага невозможен из-за отсутствия `pwsh` в среде, поэтому полноценный прогон workflow не выполнялся.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69925921a1b8832c9eaa950e0348d957)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix solution auto-detection count check in Windows build workflow

- Wrap `Get-ChildItem` result in explicit array to handle single file case

- Ensures `.Count` property works correctly for 0/1/N solution files


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Get-ChildItem result"] -->|"Wrap in @()"| B["Explicit array"]
  B -->|"Reliable .Count"| C["Correct detection logic"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-and-release-exe.yml</strong><dd><code>Wrap solution detection in explicit array</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build-and-release-exe.yml

<ul><li>Wrapped <code>Get-ChildItem</code> output in explicit array syntax <code>@(...)</code> to ensure <br><code>.Count</code> property works correctly<br> <li> Fixes issue where single file result was not treated as array, causing <br>count check to fail<br> <li> Ensures proper handling of 0, 1, or multiple <code>.sln</code> files in build <br>directory</ul>


</details>


  </td>
  <td><a href="https://github.com/ARTEMKOPIK/CllineAI/pull/23/files#diff-e77f3df32bf44b8c74f3d69f47f7a7feb45ccf1210875be61a8123c4a5be93d0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

