### PR TITLE
Codex-generated pull request

### DIFF
--- a/.github/workflows/build-and-release-exe.yml
+++ b/.github/workflows/build-and-release-exe.yml
@@ -120,26 +120,25 @@ jobs:
       - name: Build CleanAI
         shell: pwsh
         run: |
-          # Try explicit restore first. Some generated Visual Studio solutions do not
-          # expose the Restore target (for example, pure native C++ projects without
-          # NuGet references), so restore failures are treated as non-fatal.
-          $solutionPath = "build/CleanAI.sln"
-          if (-not (Test-Path $solutionPath)) {
-            $detectedSolutions = @(Get-ChildItem -Path build -Filter *.sln -File -ErrorAction SilentlyContinue)
-            if ($detectedSolutions.Count -eq 1) {
-              $solutionPath = $detectedSolutions[0].FullName
-              Write-Warning "Using detected solution path: $solutionPath"
-            }
-            else {
-              throw "Expected Visual Studio solution not found at build/CleanAI.sln and auto-detection failed."
-            }
-          }
-
+          # Best-effort restore for Visual Studio generators.
+          # This must not fail the pipeline because CMake can still build native targets
+          # even when no .sln is generated (or when Restore target is unavailable).
           $msbuild = Get-Command msbuild -ErrorAction SilentlyContinue
           if ($msbuild) {
-            & $msbuild.Source $solutionPath /t:Restore /p:Configuration=Release /p:Platform=x64 /m
-            if ($LASTEXITCODE -ne 0) {
-              Write-Warning "MSBuild restore failed with exit code $LASTEXITCODE. Continuing to build because Restore may be unavailable for this generated native solution."
+            $detectedSolutions = @(Get-ChildItem -Path build -Filter *.sln -File -Recurse -ErrorAction SilentlyContinue)
+            if ($detectedSolutions.Count -ge 1) {
+              $solutionPath = $detectedSolutions[0].FullName
+              if ($detectedSolutions.Count -gt 1) {
+                Write-Warning "Multiple .sln files detected under build/. Using first: $solutionPath"
+              }
+
+              & $msbuild.Source $solutionPath /t:Restore /p:Configuration=Release /p:Platform=x64 /m
+              if ($LASTEXITCODE -ne 0) {
+                Write-Warning "MSBuild restore failed with exit code $LASTEXITCODE. Continuing because Restore may be unavailable for this generated native solution."
+              }
+            }
+            else {
+              Write-Warning "No .sln file found under build/. Skipping MSBuild restore and continuing with CMake build."
             }
           }
           else {


### PR DESCRIPTION
### **User description**
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69925dcac0e8832cb7aa5b0b1cee0d74)


___

### **PR Type**
Bug fix


___

### **Description**
- Refactored MSBuild restore logic to handle missing .sln files gracefully

- Changed build step to not fail when no Visual Studio solution exists

- Improved error handling with better warning messages for edge cases

- Added recursive search for .sln files and multiple file detection


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Check MSBuild availability"] --> B["Search for .sln files recursively"]
  B --> C{"Solutions found?"}
  C -->|Yes| D["Run MSBuild restore"]
  D --> E{"Restore succeeds?"}
  E -->|No| F["Warn and continue"]
  E -->|Yes| G["Proceed with build"]
  C -->|No| H["Warn and skip restore"]
  H --> G
  A -->|No MSBuild| I["Skip restore, continue"]
  I --> G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-and-release-exe.yml</strong><dd><code>Make build step resilient to missing .sln files</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build-and-release-exe.yml

<ul><li>Refactored solution detection logic to search recursively and handle <br>multiple .sln files<br> <li> Changed behavior to warn instead of fail when no .sln file is found<br> <li> Improved MSBuild restore error handling to be non-fatal and continue <br>pipeline<br> <li> Enhanced warning messages to provide clearer context about detected <br>solutions and failures</ul>


</details>


  </td>
  <td><a href="https://github.com/ARTEMKOPIK/CllineAI/pull/29/files#diff-e77f3df32bf44b8c74f3d69f47f7a7feb45ccf1210875be61a8123c4a5be93d0">+16/-17</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

